### PR TITLE
Added test case and removed unnecessary std::cout

### DIFF
--- a/Algebra-polynom/Algebra-polynom/Polynom/Polynom.cpp
+++ b/Algebra-polynom/Algebra-polynom/Polynom/Polynom.cpp
@@ -773,10 +773,7 @@ Matrix Polynom::buildBerlekampMatrix() const {
             else {
                 matrix.setElement(i, j, M[i].getTermKey(j)-1);
             }
-
-            cout << matrix.getElement(i,j);
         }
-        cout << endl;
     }
     return matrix;
 }

--- a/Algebra-polynom/Algebra-polynom/Test/Test.cpp
+++ b/Algebra-polynom/Algebra-polynom/Test/Test.cpp
@@ -437,6 +437,19 @@ TEST_CASE("Roots of the polynomial") {
             REQUIRE(x.valueAtPoint(ans[i].getTermKey(0)) == 0);
         }
     }
+
+    SUBCASE("Eights example") {
+        x = Polynom(5, 
+            { -2,-1,1,2,-1,1 });
+
+        std::vector<Polynom> ans = x.findRoots();
+
+        REQUIRE(ans.size() == x.rootsNumber());
+
+        for (int i = 0, size = ans.size(); i < size; ++i) {
+            REQUIRE(x.valueAtPoint(ans[i].getTermKey(0)) == 0);
+        }
+    }
 }
 
 TEST_CASE("Cyclotomic polynomials")


### PR DESCRIPTION
Added subcase in the findRoots() test.
Removed cout from buildBerlekampMatrix function.